### PR TITLE
Fix Typing Declaration

### DIFF
--- a/moment.d.ts
+++ b/moment.d.ts
@@ -733,4 +733,6 @@ declare namespace moment {
 
 }
 
-export = moment;
+declare module "moment" {
+  export = moment;
+}


### PR DESCRIPTION
TypeScript requires a module to be declared in order to use the required `import * moment from 'moment'`. This is as described on #4619, however it was never PR'd or otherwise implemented.